### PR TITLE
Allow hidden ore to be configured for worldguard regions.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.mineinabyss.kotlinSpice
 import com.mineinabyss.sharedSetup
 
 
@@ -21,14 +20,17 @@ repositories {
 	maven("https://oss.sonatype.org/content/groups/public/")
 	maven("https://repo.mineinabyss.com/releases")
 	maven("https://papermc.io/repo/repository/maven-public/") //Paper
+	maven("https://maven.enginehub.org/repo/")
 }
 
 val serverVersion: String by project
 val kotlinVersion: String by project
+val worldGuardVersion: String by project
 
 
 dependencies {
 	compileOnly("io.papermc.paper:paper-api:$serverVersion")
+	compileOnly("com.sk89q.worldguard:worldguard-bukkit:$worldGuardVersion")
 }
 
 publishing {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ group=com.github.devotedmc
 version=1.8.0
 kotlinVersion=1.5.0
 serverVersion=1.17.1-R0.1-SNAPSHOT
-
+worldGuardVersion=7.0.5

--- a/src/main/java/com/github/devotedmc/hiddenore/HiddenOre.java
+++ b/src/main/java/com/github/devotedmc/hiddenore/HiddenOre.java
@@ -1,19 +1,16 @@
 package com.github.devotedmc.hiddenore;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Level;
-
-import org.bukkit.Bukkit;
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitTask;
-
 import com.github.devotedmc.hiddenore.commands.CommandHandler;
 import com.github.devotedmc.hiddenore.listeners.BlockBreakListener;
 import com.github.devotedmc.hiddenore.listeners.ExploitListener;
 import com.github.devotedmc.hiddenore.listeners.WorldGenerationListener;
 import com.github.devotedmc.hiddenore.tracking.BreakTracking;
+import java.util.ArrayList;
+import java.util.List;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
 
 public class HiddenOre extends JavaPlugin {
 

--- a/src/main/java/com/github/devotedmc/hiddenore/RegionNameSupplier.java
+++ b/src/main/java/com/github/devotedmc/hiddenore/RegionNameSupplier.java
@@ -1,0 +1,12 @@
+package com.github.devotedmc.hiddenore;
+
+import java.util.Collections;
+import java.util.List;
+import org.bukkit.Location;
+
+@FunctionalInterface
+interface RegionNameSupplier {
+	RegionNameSupplier NOOP_REGION_ITERATOR = (location) -> Collections.emptyList();
+
+	List<String> getRegionsForLocation(Location location);
+}

--- a/src/main/java/com/github/devotedmc/hiddenore/listeners/BlockBreakListener.java
+++ b/src/main/java/com/github/devotedmc/hiddenore/listeners/BlockBreakListener.java
@@ -1,9 +1,23 @@
 package com.github.devotedmc.hiddenore.listeners;
 
+import com.github.devotedmc.hiddenore.BlockConfig;
+import com.github.devotedmc.hiddenore.Config;
+import com.github.devotedmc.hiddenore.DropConfig;
+import com.github.devotedmc.hiddenore.HiddenOre;
+import com.github.devotedmc.hiddenore.ToolConfig;
+import com.github.devotedmc.hiddenore.VeinConfig;
+import com.github.devotedmc.hiddenore.events.HiddenOreEvent;
+import com.github.devotedmc.hiddenore.events.HiddenOreGenerateEvent;
+import com.github.devotedmc.hiddenore.util.FakePlayer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.logging.Level;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.ChatColor;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
@@ -19,22 +33,6 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
-import java.util.UUID;
-import java.util.logging.Level;
-
-import com.github.devotedmc.hiddenore.BlockConfig;
-import com.github.devotedmc.hiddenore.DropConfig;
-import com.github.devotedmc.hiddenore.HiddenOre;
-import com.github.devotedmc.hiddenore.Config;
-import com.github.devotedmc.hiddenore.ToolConfig;
-import com.github.devotedmc.hiddenore.VeinConfig;
-import com.github.devotedmc.hiddenore.events.HiddenOreEvent;
-import com.github.devotedmc.hiddenore.events.HiddenOreGenerateEvent;
-import com.github.devotedmc.hiddenore.util.FakePlayer;
 
 /**
  * Heart of ore generation, handles breaks.
@@ -81,7 +79,7 @@ public class BlockBreakListener implements Listener {
 
 		UUID world = b.getWorld().getUID();
 
-		BlockConfig bc = Config.isDropBlock(world, bd);
+		BlockConfig bc = Config.isDropBlock(world, bd, event.getBlock().getLocation());
 
 		Player p = event.getPlayer();
 		

--- a/src/main/java/com/github/devotedmc/hiddenore/listeners/WorldGenerationListener.java
+++ b/src/main/java/com/github/devotedmc/hiddenore/listeners/WorldGenerationListener.java
@@ -1,10 +1,12 @@
 package com.github.devotedmc.hiddenore.listeners;
 
+import com.github.devotedmc.hiddenore.BlockConfig;
+import com.github.devotedmc.hiddenore.Config;
+import com.github.devotedmc.hiddenore.HiddenOre;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
-
 import org.bukkit.Chunk;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -16,10 +18,6 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.world.ChunkPopulateEvent;
 import org.bukkit.inventory.ItemStack;
-
-import com.github.devotedmc.hiddenore.BlockConfig;
-import com.github.devotedmc.hiddenore.Config;
-import com.github.devotedmc.hiddenore.HiddenOre;
 
 /**
  * Populator to strip out blocks selectively from a world during generation. 
@@ -175,7 +173,7 @@ public class WorldGenerationListener implements Listener {
 			for(int z = 0; z < 16; z++) {
 				for(int y = 0; y < xzmax; y++) {
 					Block block = chunk.getBlock(x, y, z);
-					BlockConfig bc = Config.isDropBlock(world, block.getBlockData());
+					BlockConfig bc = Config.isDropBlock(world, block.getBlockData(), block.getLocation());
 					if(bc == null) continue;
 					for(BlockFace face : faces) {
 						if(block.getRelative(face).getType() == Material.AIR) {

--- a/src/main/java/com/github/devotedmc/hiddenore/tracking/BreakTracking.java
+++ b/src/main/java/com/github/devotedmc/hiddenore/tracking/BreakTracking.java
@@ -1,5 +1,7 @@
 package com.github.devotedmc.hiddenore.tracking;
 
+import com.github.devotedmc.hiddenore.Config;
+import com.github.devotedmc.hiddenore.HiddenOre;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
@@ -13,13 +15,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.logging.Level;
-
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.ChunkSnapshot;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.Block;
-
-import com.github.devotedmc.hiddenore.Config;
-import com.github.devotedmc.hiddenore.HiddenOre;
-import org.bukkit.configuration.ConfigurationSection;
 
 /**
  * A critical component of HiddenOre is preventing gaming of the ore generation system.
@@ -594,7 +596,7 @@ public class BreakTracking {
 			// quick layer scan for air and water
 			for (int x = 0; x < 16; x++) {
 				for (int z = 0; z < 16; z++) {
-					Block b = chunk.getBlock(x, Math.abs(loc.getWorld().getMinHeight()) - Y, z);
+					Block b = chunk.getBlock(x, Y - Math.abs(loc.getWorld().getMinHeight()), z);
 					if (b.isEmpty() || b.isLiquid()) {
 						layers[Y]++;
 					}

--- a/src/main/resources/config-advanced.yml
+++ b/src/main/resources/config-advanced.yml
@@ -117,3 +117,35 @@ worlds:
       minAmount: 4
       maxAmount: 6
       transformIfAble: true
+regions:
+  test:
+    blocks:
+      stone:
+        material: STONE
+        validTransforms:
+          cobblestone:
+            material: COBBLESTONE
+          dirt:
+            material: DIRT
+        dropMultiple: false
+        drops:
+          coal_ore:
+            package:
+              - ==: org.bukkit.inventory.ItemStack
+                v: 1
+                type: COAL_ORE
+                amount: 1
+            tools:
+              - wood_pickaxe
+              - stone_pickaxe
+              - iron_pickaxe
+              - gold_pickaxe
+              - diamond_pickaxe
+            minY: 1
+            maxY: 131
+            chance: 0.1
+            minAmount: 2
+            maxAmount: 8
+            transformIfAble: true
+            transformDropIfFails: true
+            transformMaxDropsIfFails: 4

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,13 +7,14 @@ load: POSTWORLD
 api-version: 1.13
 website: https://www.github.com/DevotedMC/HiddenOre
 description: HiddenOre allows the complete disguising of ores from players by not generating them in the first place, instead using a probability model to generate configurable ore layouts in response to player mining.
+softdepend: [WorldGuard]
 commands:
    hiddenore:
       description: HiddenOre allows the hiding of cool drops underground. This reloads the config.
       usage: |
        /hiddenore    -- reloads
        /hiddenore save -- forces save of tracking
-       /hiddenore generate [num] -- drops all drops near the player issuing the command, use sparingly. 
+       /hiddenore generate [num] -- drops all drops near the player issuing the command, use sparingly.
       permission: hiddenore.adv
 permissions:
     hiddenore.*:


### PR DESCRIPTION
Regions take precedence over world/global config. If multiple regions overlap the region with highest priority (leaf node generally) takes precedence.

Also fix bug in block tracking.

`minHeight - Y` returns negative values for normal worlds starting at block 0. This should have been `Y - minHeight` I believe to shift negative Y values into positive indices.